### PR TITLE
Clear stale positions when unobserving/disconnecting

### DIFF
--- a/.changeset/clear-stale-positions.md
+++ b/.changeset/clear-stale-positions.md
@@ -1,0 +1,5 @@
+---
+"position-observer": patch
+---
+
+Fixed a bug where observing an element that had previously been observed and unobserved would not trigger the `PositionObserverCallback` when if the position of the element had not changed after it being unobserved.

--- a/src/PositionObserver.ts
+++ b/src/PositionObserver.ts
@@ -95,6 +95,7 @@ export class PositionObserver {
     if (element) {
       this.#positionObservers.get(element)?.disconnect();
       this.#visibilityObserver.unobserve(element);
+      this.#positions.delete(element);
     } else {
       this.disconnect();
     }
@@ -108,6 +109,7 @@ export class PositionObserver {
       positionObserver.disconnect();
     }
 
+    this.#positionObservers.clear();
     this.#resizeObserver.disconnect();
     this.#rootBoundsObserver.disconnect();
     this.#visibilityObserver.disconnect();


### PR DESCRIPTION
Fixed a bug where observing an element that had previously been observed and unobserved would not trigger the `PositionObserverCallback` when if the position of the element had not changed after it being unobserved.