### PR TITLE
Ensure `intersectionRect` is always a `DOMRect` instance

### DIFF
--- a/.changeset/visible-rect-domrect.md
+++ b/.changeset/visible-rect-domrect.md
@@ -1,0 +1,5 @@
+---
+"position-observer": patch
+---
+
+Fixed a bug where `intersectionRect` in `PositionObserverEntry` could sometimes be an object instead of an instance of `DOMRect`.

--- a/src/observers/PositionIntersectionObserver.ts
+++ b/src/observers/PositionIntersectionObserver.ts
@@ -50,7 +50,7 @@ export class PositionIntersectionObserver {
    *
    * @returns The visible rectangle of the element within the root.
    */
-  get visibleRect() {
+  get visibleRect(): DOMRect {
     const clip = this.#options.clip;
     return clip ? Rect.clip(this.#clientRect, clip) : this.#clientRect;
   }

--- a/src/utilities/Rect.ts
+++ b/src/utilities/Rect.ts
@@ -29,7 +29,7 @@ export class Rect {
   static clip(
     rect: DOMRect,
     clip: Pick<DOMRect, "top" | "right" | "bottom" | "left">
-  ) {
+  ): DOMRect {
     const updatedRect = {
       ...rect.toJSON(),
       top: rect.top + clip.top,
@@ -41,7 +41,12 @@ export class Rect {
     updatedRect.width = updatedRect.right - updatedRect.left;
     updatedRect.height = updatedRect.bottom - updatedRect.top;
 
-    return updatedRect;
+    return new DOMRect(
+      updatedRect.x,
+      updatedRect.y,
+      updatedRect.width,
+      updatedRect.height
+    );
   }
 
   /**


### PR DESCRIPTION
Fixed a bug where `intersectionRect` in `PositionObserverEntry` could sometimes be an object instead of an instance of `DOMRect`.